### PR TITLE
Feature to allow blocking post for publishing using post settings

### DIFF
--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -92,9 +92,10 @@ class Admin_Apple_Async extends Apple_News {
 		}
 
 		/**
-		 * MS-1077: Server-side guard to avoid pushing the article if the field
+		 * Server-side guard to avoid pushing the article if the field
 		 * "Remove this post from outbound syndication feeds" is checked on the
 		 * Post Settings > Distribution tab.
+		 * Button Publish won't be displayed on the article list, but we never know.
 		 */
 		if ( Admin_Apple_News::is_post_blocked_for_outbound_syndication( $post_id ) ) {
 			Admin_Apple_Notice::error(

--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -91,6 +91,23 @@ class Admin_Apple_Async extends Apple_News {
 			return;
 		}
 
+		/**
+		 * MS-1077: Server-side guard to avoid pushing the article if the field
+		 * "Remove this post from outbound syndication feeds" is checked on the
+		 * Post Settings > Distribution tab.
+		 */
+		if ( Admin_Apple_News::is_post_blocked_for_outbound_syndication( $post_id ) ) {
+			Admin_Apple_Notice::error(
+				sprintf(
+					// translators: token is the post title.
+					__( 'Article %s is excluded from outbound syndication feeds and cannot be pushed to Apple News.', 'apple-news' ),
+					$post->post_title
+				),
+				$user_id
+			);
+			return;
+		}
+
 		$action = new Apple_Actions\Index\Push( $this->settings, $post_id );
 		try {
 			$action->perform( true, $user_id );

--- a/admin/class-admin-apple-news-list-table.php
+++ b/admin/class-admin-apple-news-list-table.php
@@ -285,7 +285,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 				 * "Remove this post from outbound syndication feeds" is checked on the
 				 * Post Settings > Distribution tab making the post blocked for outbound syndication.
 				 */
-				Admin_Apple_News::is_post_blocked_for_outbound_syndication( $item->ID ) ? ' <b>' . __('Unable to publish - Marked as removed for outbound syndication feeds', 'apple-news' ) . '</b>' : '',
+				Admin_Apple_News::is_post_blocked_for_outbound_syndication( $item->ID ) ? '<br><br><i><b>' . __('Unable to publish', 'apple-news' ) . '</b> - ' . __('Blocked for outbound syndication feeds on the Post Distribution Settings', 'apple-news' ) . '</i>' : '',
 				$this->row_actions( $actions ), // Can't be escaped but all elements are fully escaped above.
 			),
 			$item,
@@ -313,7 +313,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 				'title'      => __( 'Title', 'apple-news' ),
 				'updated_at' => __( 'Last updated at', 'apple-news' ),
 				'status'     => __( 'Apple News Status', 'apple-news' ),
-				'blocked'    => __( 'Removed from outbound syndication', 'apple-news' ), // Column to show if the article if blocked for outbound syndication.
+				'blocked'    => __( 'Blocked for outbound syndication', 'apple-news' ), // Column to show if the article if blocked for outbound syndication.
 				'sync'       => __( 'Sync Status', 'apple-news' ),
 			]
 		);

--- a/admin/class-admin-apple-news-list-table.php
+++ b/admin/class-admin-apple-news-list-table.php
@@ -77,7 +77,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 				break;
 
 			/**
-			 * MS-1077: Column to show if the field "Remove this post from outbound syndication feeds"
+			 * Column to show if the field "Remove this post from outbound syndication feeds"
 			 * is checked on the Post Settings > Distribution tab making the post blocked for outbound syndication.
 			 */
 			case 'blocked':
@@ -215,7 +215,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 		];
 
 		/**
-		 * MS-1077: Does not show the "Publish" button if the field "Remove this post from outbound syndication feeds"
+		 * Does not show the "Publish" button if the field "Remove this post from outbound syndication feeds"
 		 * is checked on the Post Settings > Distribution tab. It shows a link to the Post Edit > Distribution tab instead.
 		 */
 		if ( Admin_Apple_News::is_post_blocked_for_outbound_syndication( $item->ID ) ) {
@@ -281,7 +281,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 				esc_html( $item->post_title ),
 				absint( $item->ID ),
 				/**
-				 *  MS-1077: Mark the article with message "Unable to publish..." if the field
+				 *  Mark the article with message "Unable to publish..." if the field
 				 * "Remove this post from outbound syndication feeds" is checked on the
 				 * Post Settings > Distribution tab making the post blocked for outbound syndication.
 				 */
@@ -313,7 +313,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 				'title'      => __( 'Title', 'apple-news' ),
 				'updated_at' => __( 'Last updated at', 'apple-news' ),
 				'status'     => __( 'Apple News Status', 'apple-news' ),
-				'blocked'    => __( 'Removed from outbound syndication', 'apple-news' ), // MS-1077: Column to show if the article if blocked for outbound syndication.
+				'blocked'    => __( 'Removed from outbound syndication', 'apple-news' ), // Column to show if the article if blocked for outbound syndication.
 				'sync'       => __( 'Sync Status', 'apple-news' ),
 			]
 		);

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -44,7 +44,7 @@ class Admin_Apple_News extends Apple_News {
 	public static $settings;
 
 	/**
-	 * MS-1077: Array to store posts blocked for outbound syndication.
+	 * Collection to store posts blocked for outbound syndication.
 	 * This collection is filled up considering value of the field
 	 * "Remove this post from outbound syndication feeds" available on
 	 * Post Edit Settings > Distribution tab.
@@ -216,9 +216,9 @@ class Admin_Apple_News extends Apple_News {
 		}
 
 		/**
-		 * MS-1077: Add a "Distribution" tab to the post settings Fieldmanager
-		 * group if it does not exists and add the field "Remove this post from outbound syndication feeds"
-		 * checkbox, default checked.
+		 * Add a "Distribution" tab to the post settings Fieldmanager
+		 * group if it does not exists and add the field
+		 * "Remove this post from outbound syndication feeds"checkbox, default checked.
 		 */
 		add_filter( 'lakana_post_settings_group_children', array( $this, 'filter_post_settings_group_children' ) );
 		add_filter( 'update_post_metadata', array( $this, 'save_post_excluded_option_value' ), 10, 4 ); // Intercept saving value exclude_from_feeds to post meta.

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -27,8 +27,8 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		<?php
 		printf(
 			/* translators: First token is opening a tag, second is closing a tag */
-			esc_html__( 'You must enter your API information on the %1$ssettings page%2$s before using Publish to Apple News.', 'apple-news' ),
-			'<a href="' . esc_url( admin_url( 'admin.php?page=apple-news-options' ) ) . '">',
+			esc_html__( 'You must fill in the fields API Channel, API Key and API Secret on the section "Apple News Key for Lower Environments" on %1$s"Network > Settings > Network Settings"%2$s page before using Publish to Apple News.', 'apple-news' ),
+			'<a href="' . esc_url( network_admin_url( 'settings.php?page=network_models' ) ) . '">',
 			'</a>'
 		);
 		?>

--- a/admin/partials/page-index.php
+++ b/admin/partials/page-index.php
@@ -17,8 +17,8 @@ $apple_current_screen = get_current_screen(); ?>
 			<?php
 			printf(
 				/* translators: First token is opening a tag, second is closing a tag */
-				esc_html__( 'You must enter your API information on the %1$ssettings page%2$s before using Publish to Apple News.', 'apple-news' ),
-				'<a href="' . esc_url( admin_url( 'admin.php?page=apple-news-options' ) ) . '">',
+				esc_html__( 'You must fill in the fields API Channel, API Key and API Secret on the section "Apple News Key for Lower Environments" on %1$s"Network > Settings > Network Settings"%2$s page before using Publish to Apple News.', 'apple-news' ),
+				'<a href="' . esc_url( network_admin_url( 'settings.php?page=network_models' ) ) . '">',
 				'</a>'
 			);
 			?>

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -8,27 +8,6 @@
  *
  * @package Apple_News
  */
-
-// Guarantee that the settings form was submitted before taking any action.
-if ( isset( $_REQUEST['apple_news_excluded_posts_action'] ) ) {
-	$currently_excluded_posts_ids = get_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, [] );
-	$request_excluded_posts_ids = $_REQUEST[Admin_Apple_News::EXCLUDED_POSTS_OPTION];
-
-	// Add a guard to guarantee that all post ids are integers otherwise in_array won't work - we never know, right?
-	$currently_excluded_posts_ids = array_map( 'intval', $currently_excluded_posts_ids );
-	$request_excluded_posts_ids = array_map( 'intval', $request_excluded_posts_ids ?? [] );
-
-	// Remove from the currently excluded posts ids the ones that weren't checked on the form.
-	foreach( $currently_excluded_posts_ids as $key => $current_excluded_post_id ) {
-		if ( ! in_array( $current_excluded_post_id, $request_excluded_posts_ids, true ) ) {
-			unset( $currently_excluded_posts_ids[ $key ] );
-		}
-	}
-
-	// Update the option with the new list of excluded posts ids.
-	update_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, $currently_excluded_posts_ids );
-}
-
 ?>
 <div class="wrap apple-news-settings">
 	<h1><?php esc_html_e( 'Manage Settings', 'apple-news' ); ?></h1>
@@ -67,15 +46,8 @@ if ( isset( $_REQUEST['apple_news_excluded_posts_action'] ) ) {
 
 				echo '<ul class="apple-news-settings-excluded-posts">';
 
-				// action control hidden field
-				echo '<input type="hidden" name="apple_news_excluded_posts_action" value="1" />';
-
-				// nonce field
-				wp_nonce_field( 'apple_news_excluded_posts_action', 'apple_news_excluded_posts_nonce' );
-
 				foreach ( $excluded_posts as $i => $excluded_post ) {
 					echo '<li>' .
-						'<input type="checkbox" checked id="excluded-post-' . esc_attr( $i ) . '" name="' . esc_attr( Admin_Apple_News::EXCLUDED_POSTS_OPTION ) . '[]" value="' . esc_attr( $excluded_post->ID ) .'">' .
 						' <label for="excluded-post-' . esc_attr( $i ) . '">' . esc_html( get_the_title( $excluded_post ) ) . '</label>' .
 						' &nbsp;<a href="' . esc_url( get_permalink(  $excluded_post->ID ) ) .'">' . esc_html__( 'View Post' ) . '</a>' .
 						' &nbsp;<a href="' . esc_url( get_edit_post_link( $excluded_post->ID ) ) . '#fm-post_settings-0-distribution-0-tab">' . esc_html__( 'Edit Distribution Settings' ) . '</a>' .

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -31,36 +31,6 @@
 			?>
 		<?php endforeach; ?>
 
-		<h3><?php esc_html_e( 'Posts blocked for outbound syndication to Apple News', 'apple-news' ); ?></h3>
-		<?php
-			$excluded_posts_ids = get_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, [] );
-			if ( ! empty( $excluded_posts_ids ) ) {
-				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
-				$excluded_posts = get_posts( [
-					'include'          => $excluded_posts_ids,
-					'suppress_filters' => false,
-				] );
-			}
-
-			if ( count( $excluded_posts_ids ) && count( $excluded_posts ) ) {
-
-				echo '<ul class="apple-news-settings-excluded-posts">';
-
-				foreach ( $excluded_posts as $i => $excluded_post ) {
-					echo '<li>' .
-						' <label for="excluded-post-' . esc_attr( $i ) . '">' . esc_html( get_the_title( $excluded_post ) ) . '</label>' .
-						' &nbsp;<a href="' . esc_url( get_permalink(  $excluded_post->ID ) ) .'">' . esc_html__( 'View Post' ) . '</a>' .
-						' &nbsp;<a href="' . esc_url( get_edit_post_link( $excluded_post->ID ) ) . '#fm-post_settings-0-distribution-0-tab">' . esc_html__( 'Edit Distribution Settings' ) . '</a>' .
-						'</li>';
-				}
-
-				echo '</ul>';
-
-			} else {
-				echo '<p class="description">' . esc_html__( 'There are no posts manually excluded from the Apple News partner feed.', 'apple-news' ) . '</p>';
-			}
-		?>
-
 		<?php if ( is_plugin_active( 'brightcove-video-connect/brightcove-video-connect.php' ) ) : ?>
 			<h3><?php esc_html_e( 'Brightcove Support', 'apple-news' ); ?></h3>
 			<p>
@@ -74,5 +44,54 @@
 		<?php endif; ?>
 
 		<?php submit_button(); ?>
+
+		<h3><?php esc_html_e( 'Articles blocked for outbound syndication', 'apple-news' ); ?></h3>
+		<?php
+			$excluded_posts_ids = get_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, [] );
+			if ( ! empty( $excluded_posts_ids ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+				$excluded_posts = get_posts( [
+					'include'          => $excluded_posts_ids,
+					'suppress_filters' => false,
+				] );
+			}
+
+			if ( count( $excluded_posts_ids ) && count( $excluded_posts ) ) {
+
+				echo '<table class="wp-list-table widefat fixed striped table-view-list posts">';
+
+				echo '<thead>';
+				echo '<tr>';
+				echo '<th>' . esc_html__( 'Post Title', 'apple-news' ) . '</th>';
+				echo '<th>' . esc_html__( 'View Post', 'apple-news' ) . '</th>';
+				echo '<th>' . esc_html__( 'Edit Distribution Settings', 'apple-news' ) . '</th>';
+				echo '</tr>';
+				echo '</thead>';
+
+				foreach ( $excluded_posts as $i => $excluded_post ) {
+					echo '<tr>';
+
+					echo '<td>';
+					echo '<a href="' . esc_url( get_edit_post_link( $excluded_post->ID ) ) . '">' . esc_html( $excluded_post->post_title ) . '</a>';
+					echo '</td>';
+
+					echo '<td>';
+					echo '<a href="' . esc_url( get_permalink(  $excluded_post->ID ) ) .'">' . esc_html__( 'View Post' ) . '</a>';
+					echo '</td>';
+
+					echo '<td>';
+					echo '<a href="' . esc_url( get_edit_post_link( $excluded_post->ID ) ) . '#fm-post_settings-0-distribution-0-tab">' . esc_html__( 'Edit Post' ) . '</a>';
+					echo '</td>';
+
+					echo '</tr>';
+				}
+
+				echo '</table>';
+
+			} else {
+				echo '<p class="description">' . esc_html__( 'There are no posts manually blocked for outbound sybdication.', 'apple-news' ) . '</p>';
+			}
+		?>
+
 	</form>
 </div>

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -9,6 +9,26 @@
  * @package Apple_News
  */
 
+// Guarantee that the settings form was submitted before taking any action.
+if ( isset( $_REQUEST['apple_news_excluded_posts_action'] ) ) {
+	$currently_excluded_posts_ids = get_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, [] );
+	$request_excluded_posts_ids = $_REQUEST[Admin_Apple_News::EXCLUDED_POSTS_OPTION];
+
+	// Add a guard to guarantee that all post ids are integers otherwise in_array won't work - we never know, right?
+	$currently_excluded_posts_ids = array_map( 'intval', $currently_excluded_posts_ids );
+	$request_excluded_posts_ids = array_map( 'intval', $request_excluded_posts_ids ?? [] );
+
+	// Remove from the currently excluded posts ids the ones that weren't checked on the form.
+	foreach( $currently_excluded_posts_ids as $key => $current_excluded_post_id ) {
+		if ( ! in_array( $current_excluded_post_id, $request_excluded_posts_ids, true ) ) {
+			unset( $currently_excluded_posts_ids[ $key ] );
+		}
+	}
+
+	// Update the option with the new list of excluded posts ids.
+	update_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, $currently_excluded_posts_ids );
+}
+
 ?>
 <div class="wrap apple-news-settings">
 	<h1><?php esc_html_e( 'Manage Settings', 'apple-news' ); ?></h1>
@@ -31,6 +51,43 @@
 				$apple_section->after_section();
 			?>
 		<?php endforeach; ?>
+
+		<h3><?php esc_html_e( 'Posts blocked for outbound syndication to Apple News', 'apple-news' ); ?></h3>
+		<?php
+			$excluded_posts_ids = get_option( Admin_Apple_News::EXCLUDED_POSTS_OPTION, [] );
+			if ( ! empty( $excluded_posts_ids ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+				$excluded_posts = get_posts( [
+					'include'          => $excluded_posts_ids,
+					'suppress_filters' => false,
+				] );
+			}
+
+			if ( count( $excluded_posts_ids ) && count( $excluded_posts ) ) {
+
+				echo '<ul class="apple-news-settings-excluded-posts">';
+
+				// action control hidden field
+				echo '<input type="hidden" name="apple_news_excluded_posts_action" value="1" />';
+
+				// nonce field
+				wp_nonce_field( 'apple_news_excluded_posts_action', 'apple_news_excluded_posts_nonce' );
+
+				foreach ( $excluded_posts as $i => $excluded_post ) {
+					echo '<li>' .
+						'<input type="checkbox" checked id="excluded-post-' . esc_attr( $i ) . '" name="' . esc_attr( Admin_Apple_News::EXCLUDED_POSTS_OPTION ) . '[]" value="' . esc_attr( $excluded_post->ID ) .'">' .
+						' <label for="excluded-post-' . esc_attr( $i ) . '">' . esc_html( get_the_title( $excluded_post ) ) . '</label>' .
+						' &nbsp;<a href="' . esc_url( get_permalink(  $excluded_post->ID ) ) .'">' . esc_html__( 'View Post' ) . '</a>' .
+						' &nbsp;<a href="' . esc_url( get_edit_post_link( $excluded_post->ID ) ) . '#fm-post_settings-0-distribution-0-tab">' . esc_html__( 'Edit Distribution Settings' ) . '</a>' .
+						'</li>';
+				}
+
+				echo '</ul>';
+
+			} else {
+				echo '<p class="description">' . esc_html__( 'There are no posts manually excluded from the Apple News partner feed.', 'apple-news' ) . '</p>';
+			}
+		?>
 
 		<?php if ( is_plugin_active( 'brightcove-video-connect/brightcove-video-connect.php' ) ) : ?>
 			<h3><?php esc_html_e( 'Brightcove Support', 'apple-news' ); ?></h3>

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -34,7 +34,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		$this->settings = [
 			'api_config_file'       => [
 				// translators: tokens fill in <a> tags.
-				'description' => sprintf( __( 'Having trouble? %1$sEnter the contents of your .papi file manually%2$s.', 'apple-news' ), '<a href="#api_config_file">', '</a>' ),
+				'description' => sprintf( __( 'Having trouble? %1$sEnter the contents of your .papi file manually%2$s or fill in the fields API Channel, API Key and API Secret on the section "Apple News Key for Lower Environments" on "Network > Settings > Network Settings" page.', 'apple-news' ), '<a href="#api_config_file">', '</a>' ),
 				'type'        => 'file',
 			],
 			'api_config_file_input' => [

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -344,7 +344,7 @@ class Apple_News {
 		if ( ! self::is_initialized() ) {
 			return new WP_Error(
 				'apple_news_bad_operation',
-				__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
+				__( 'You must fill in the fields API Channel, API Key and API Secret on the section "Apple News Key for Lower Environments" on "Network > Settings > Network Settings" page before using Publish to Apple News.', 'apple-news' ),
 				[
 					'status' => 400,
 				]


### PR DESCRIPTION
This PR intends to add a feature on Apple News plugin to support blocking a post for publishing using post settings.

## Added
- Add a "Distribution" tab to the post settings Fieldmanager group if it does not exists and add the field "Remove this post from outbound syndication feeds" checkbox, default checked.
![image](https://user-images.githubusercontent.com/90911997/208775171-33dbdd58-3545-4d3a-b3c9-6e90dbf3979c.png)
- Column on articles list to show if the field "Remove this post from outbound syndication feeds" is checked
![image](https://user-images.githubusercontent.com/90911997/208775256-1e56cbc5-0cf9-4835-b9e5-20ea6d3a2ffd.png)
- Check to hide "Publish" button if the field "Remove this post from outbound syndication feeds" is checked, showing a button "Edit Distribution Settings" and a message "Unable to publish - Marked as removed for outbound syndication feeds" otherwise. Added a server-side guard to avoid pushing the article anyway.
![image](https://user-images.githubusercontent.com/90911997/208777926-4e33a646-0004-4424-a46a-ddf1cb447dc2.png)
- List of articles blocked for publishing on plugin settings
![image](https://user-images.githubusercontent.com/90911997/208778173-e4ed2cf3-4bc9-467f-86fe-43ffb21590fb.png)
- Plugin storage to store posts blocked for outbound syndication
- Functions to retrieve and save values of this field

Also added message "fill in the fields API Channel, API Key and API Secret on the section Apple News Key for Lower Environments on Network > Settings > Network Settings page" instead of only saying that credentials need to be entered on plugin settings page, to make it easier for future users.